### PR TITLE
Fix matcher return type

### DIFF
--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -3,7 +3,7 @@ export {};
 declare global {
   namespace jest {
     interface Matchers<R> {
-      toBeFasterThan(target: number): CustomMatcherResult
+      toBeFasterThan(target: number): Promise<CustomMatcherResult>
     }
   }
 }


### PR DESCRIPTION
Current return type can result in lint errors when used with `await`.

Thanks!